### PR TITLE
Added config.json token support

### DIFF
--- a/BSBot.py
+++ b/BSBot.py
@@ -7,7 +7,7 @@ from dotenv import load_dotenv
 
 from src.cogs.errors import NoPrivateMessagesException
 from src.log import Logger
-
+import json
 
 class BSBot(commands.Bot):
     running_tests = False
@@ -50,6 +50,8 @@ if __name__ == "__main__":
     bot.load_extension(name="src.cogs.general")
     bot.load_extension(name="src.cogs.beatsaber")
 
-    load_dotenv()
-    TOKEN = os.getenv("DISCORD_TOKEN")
+    with open('config.json', 'r') as myfile:
+    	data=myfile.read()
+    data = json.loads(data)	
+    TOKEN = str(data["token"])
     bot.run(TOKEN)


### PR DESCRIPTION
This will now get the token from config.json instead of getting it from .env

You just need to create a new file in the root folder of the project called `config.json` containing someting like this

```json
{
  "token": <token_here>
}
```

and it will work, no more .env!